### PR TITLE
Add assertion

### DIFF
--- a/index.js
+++ b/index.js
@@ -443,3 +443,32 @@ exports.toPromise = function(predict, toError) {
     }
   };
 };
+
+//# bimap :: (a -> Promise b) -> (Error -> Promise b) -> Promise a -> Promise b
+//
+//. Takes two functions and return a function that can take a Promise and return a Promise.
+//. If the received Promise is resolved, the first function will be used to map over the resolved value;
+//. If the received Promise is rejected, the second function will be used to map over the Error.
+//
+//. Like Promise.prototype.then function, but takes functions first.
+//. ```js
+//. var add1OrReject = bimap(
+//.   function(n) { return n + 1; },
+//.   function(error) {
+//.     return new Error('can not add value for ' + error.message);
+//.   }
+//. );
+//.
+//. > add1OrReject(P.purep(2))
+//. promise
+//. 3
+//.
+//. > add1OrReject(Promise.reject(new Error('NaN')));
+//. promise
+//. 'can not add value for NaN'
+//. ```
+exports.bimap = function(mapResolved, mapError) {
+  return function(p) {
+    return p.then(mapResolved, mapError);
+  };
+};

--- a/test.js
+++ b/test.js
@@ -19,6 +19,7 @@ var foldp = require('./index').foldp;
 var mapError = require('./index').mapError;
 var resolveError = require('./index').resolveError;
 var toPromise = require('./index').toPromise;
+var bimap = require('./index').bimap;
 
 var Promise = require('bluebird');
 
@@ -383,6 +384,30 @@ describe('toPromise', function() {
     return promiseShouldFail(validateGreaterThan0(-10))
     .then(function(error) {
       expect(error.message).to.equal('value is not greater than 0');
+    });
+  });
+});
+
+describe('bimap', function() {
+  var add1OrReject = bimap(
+    function(n) {
+      return n + 1;
+    },
+    function(error) {
+      return Promise.reject(new Error('reject ' + error.message));
+    }
+  );
+
+  it('should resolve', function() {
+    return add1OrReject(Promise.resolve(2)).then(function(r) {
+      expect(r).to.equal(3);
+    });
+  });
+
+  it('should fail', function() {
+    return promiseShouldFail(add1OrReject(Promise.reject(new Error('NaN'))))
+    .then(function(error) {
+      expect(error.message).to.equal('reject NaN');
     });
   });
 });

--- a/test.js
+++ b/test.js
@@ -70,6 +70,11 @@ describe('liftp', function() {
     });
   });
 
+  it('should throw if type mismatch', function() {
+    return expect(function() {
+      liftp(123);
+    }).to.throw(TypeError);
+  });
 });
 
 describe('liftp1', function() {
@@ -78,9 +83,15 @@ describe('liftp1', function() {
       return user.email;
     })(Promise.resolve({ email: 'abc@example.com' }));
   });
+
+  it('should throw if type mismatch', function() {
+    return expect(function() {
+      liftp1(123);
+    }).to.throw(TypeError);
+  });
 });
 
-describe('liftp1', function() {
+describe('liftp2', function() {
   it('resolve', function() {
     return liftp2(function(a, b) {
       return a + b;
@@ -91,8 +102,7 @@ describe('liftp1', function() {
   });
 });
 
-
-describe('liftp1', function() {
+describe('liftp2', function() {
   it('resolve', function() {
     return liftp2(function(a, b) {
       return a + b;


### PR DESCRIPTION
### Problem:
```
var Promise = require('bluebird');
Promise.resolve(12).then(undefined).then(console.log);
```

The above code will print `1` without any error. This is problematic, if one made a typo in the function name, and passed an `undefined` value to the `then` function. The promise will be resolved without throwing any error. 

### Solution:
This PR is going to add assertion to functions. For example if an `undefined` value gets passed to `liftp` instead of a function, it will throw a TypeError to draw user's attention.